### PR TITLE
Update customer ext test status code 200 to 201

### DIFF
--- a/test/api/extensions/customer-ext.spec.js
+++ b/test/api/extensions/customer-ext.spec.js
@@ -19,7 +19,7 @@ describe("Customer Endpoint", () => {
                 .put(`/customers/${customer.id}`)
                 .send(request)
 
-            expect(response.status).toEqual(200)
+            expect(response.status).toEqual(201)
             expect(response.body.customer).not.toEqual(undefined)
             expect(response.body.customer.name).toEqual(request.name)
             expect(response.body.customer.contact).not.toEqual(undefined)


### PR DESCRIPTION
Updated Customer PUT extension test to expect status code of 201 for successful operation instead of 200 as per the provided OpenAPI spec to the students.