### PR TITLE
Update setupTests.js

### DIFF
--- a/test/setupTests.js
+++ b/test/setupTests.js
@@ -12,6 +12,9 @@ const deleteTables = () => {
   return prisma.$transaction(deleteTables)
 }
 
+global.beforeAll(() => {
+  return deleteTables()
+})
 
 global.afterEach(() => {
   return deleteTables()


### PR DESCRIPTION
If the DB was not empty, at the first run, the first tests was failing because it wasn't deleting everything from the DB.